### PR TITLE
Add filter to create admin notice in shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,12 @@ Use the "WPIS-" -prefix followed by the name of your instance to name the consta
 Use the hash part of your container name to define the constant value. If the name of
 your container is "asdasd_123", use "123" to define the value.
 
+## Filters
+
+You can insert your own admin notice for users that are in shadow
+```php
+function my_shadow_admin_notice($admin_notice, $current_screen) {
+  return '<div class="notice notice-error"><p>This is staging. All content edited here will be lost. Return to production to create or edit content.</p></div>';
+}
+add_filter( 'wpp_instance_switcher_admin_notice', 'my_shadow_admin_notice', 10, 2 );
+```

--- a/wp-palvelu-instance-switcher.php
+++ b/wp-palvelu-instance-switcher.php
@@ -63,6 +63,7 @@ class WPP_Instance_Switcher {
       add_action('admin_footer', array( $this, 'render_shadow_indicator' ) );
       add_action('wp_footer', array( $this, 'render_shadow_indicator' ) );
       add_action('login_footer', array( $this, 'render_shadow_indicator' ) );
+      add_action('admin_notices', array( $this, 'render_shadow_admin_notice' ) );
     }
   }
 
@@ -177,6 +178,17 @@ class WPP_Instance_Switcher {
 <?php echo wp_sprintf( __('You are currently in %s.', 'wpp-instance-switcher'), getenv( 'WP_ENV' ) ); ?> <a class="clearlink" href="/?wpp_shadow=clear"><?php _e('Exit', 'wpp-instance-switcher'); ?></a>
 </div>
 <?php
+  }
+
+  /**
+   * Let plugins or themes display admin notice when inside a shadow
+   */
+  public function render_shadow_admin_notice( $current_screen ) {
+    $current_screen = get_current_screen();
+    $admin_notice_content = apply_filters( 'wpp_instance_switcher_admin_notice', '', $current_screen );
+    if(!empty($admin_notice_content)) {
+      echo $admin_notice_content;
+    }
   }
 
   /**


### PR DESCRIPTION
Sometimes you need to give rules for logged in users how to handle the content. In some occasions you do want them to create new content in shadow and other times never do any content editing in shadow. Here's a simple filter for plugins or themes to create their own message that is displayed on some screens or all of them.

I couldn't really test this because of the nature of this plugin. If you have a testing environment for the plugin, test that the example given works. I couldn't really do any escaping for the admin_notice because I wanted it to be as easy as possible to change the CSS classes, markup, content etc.